### PR TITLE
Update VS Code launch configuration from netcoreapp3.0 to net8

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/csharp/Platform.Reflection.Benchmarks/bin/Debug/netcoreapp3.0/Platform.Reflection.Benchmarks.dll",
+      "program": "${workspaceFolder}/csharp/Platform.Reflection.Benchmarks/bin/Debug/net8/Platform.Reflection.Benchmarks.dll",
       "args": [],
       "cwd": "${workspaceFolder}/csharp/Platform.Reflection.Benchmarks",
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Reflection/issues/60
-Your prepared branch: issue-60-b9f83249
-Your prepared working directory: /tmp/gh-issue-solver-1757784134807
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Reflection/issues/60
+Your prepared branch: issue-60-b9f83249
+Your prepared working directory: /tmp/gh-issue-solver-1757784134807
+
+Proceed.


### PR DESCRIPTION
## Summary

- Updates the VS Code launch.json configuration to use `net8` instead of the outdated `netcoreapp3.0` framework reference
- Aligns the debug configuration with the current project target framework

## Details

The issue #60 originally requested updating from `netcoreapp3.0` to `netcoreapp3.1`, but since then the entire codebase has been modernized to use `net8`. However, the VS Code launch configuration still contained a stale reference to `netcoreapp3.0` in the program path.

This change ensures that VS Code debugging will work correctly with the current build output location.

## Files Changed

- `.vscode/launch.json`: Updated program path from `netcoreapp3.0` to `net8`

Fixes #60

🤖 Generated with Claude Code