### PR TITLE
Add XML documentation comments for all public classes and methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Reflection/issues/53
+Your prepared branch: issue-53-d191cea8
+Your prepared working directory: /tmp/gh-issue-solver-1757805448893
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Reflection/issues/53
-Your prepared branch: issue-53-d191cea8
-Your prepared working directory: /tmp/gh-issue-solver-1757805448893
-
-Proceed.

--- a/csharp/Platform.Reflection/AssemblyExtensions.cs
+++ b/csharp/Platform.Reflection/AssemblyExtensions.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using Platform.Exceptions;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {
@@ -19,6 +18,20 @@ namespace Platform.Reflection
     {
         private static readonly ConcurrentDictionary<Assembly, Type[]> _loadableTypesCache = new ConcurrentDictionary<Assembly, Type[]>();
 
+        /// <summary>
+        /// <para>
+        /// Gets the loadable types using the specified assembly.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="assembly">
+        /// <para>The assembly.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>The type array</para>
+        /// <para></para>
+        /// </returns>
         /// <remarks>
         /// Source: http://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx/
         /// </remarks>

--- a/csharp/Platform.Reflection/DelegateHelpers.cs
+++ b/csharp/Platform.Reflection/DelegateHelpers.cs
@@ -5,7 +5,6 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using Platform.Exceptions;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {

--- a/csharp/Platform.Reflection/DynamicExtensions.cs
+++ b/csharp/Platform.Reflection/DynamicExtensions.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {
@@ -19,7 +18,7 @@ namespace Platform.Reflection
         /// </para>
         /// <para></para>
         /// </summary>
-        /// <param name="@object">
+        /// <param name="object">
         /// <para>The object.</para>
         /// <para></para>
         /// </param>

--- a/csharp/Platform.Reflection/EnsureExtensions.cs
+++ b/csharp/Platform.Reflection/EnsureExtensions.cs
@@ -5,7 +5,6 @@ using Platform.Exceptions;
 using Platform.Exceptions.ExtensionRoots;
 
 #pragma warning disable IDE0060 // Remove unused parameter
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {

--- a/csharp/Platform.Reflection/FieldInfoExtensions.cs
+++ b/csharp/Platform.Reflection/FieldInfoExtensions.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {

--- a/csharp/Platform.Reflection/ILGeneratorExtensions.cs
+++ b/csharp/Platform.Reflection/ILGeneratorExtensions.cs
@@ -4,7 +4,6 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {

--- a/csharp/Platform.Reflection/MethodInfoExtensions.cs
+++ b/csharp/Platform.Reflection/MethodInfoExtensions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {

--- a/csharp/Platform.Reflection/NotSupportedExceptionDelegateFactory.cs
+++ b/csharp/Platform.Reflection/NotSupportedExceptionDelegateFactory.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Platform.Interfaces;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {

--- a/csharp/Platform.Reflection/NumericType.cs
+++ b/csharp/Platform.Reflection/NumericType.cs
@@ -6,7 +6,6 @@ using Platform.Exceptions;
 // ReSharper disable AssignmentInConditionalExpression
 // ReSharper disable BuiltInTypeReferenceStyle
 // ReSharper disable StaticFieldInGenericType
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {
@@ -112,7 +111,7 @@ namespace Platform.Reflection
 
         /// <summary>
         /// <para>
-        /// Initializes a new <see cref="NumericType"/> instance.
+        /// Initializes a new <see cref="NumericType{T}"/> instance.
         /// </para>
         /// <para></para>
         /// </summary>

--- a/csharp/Platform.Reflection/PropertyInfoExtensions.cs
+++ b/csharp/Platform.Reflection/PropertyInfoExtensions.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {

--- a/csharp/Platform.Reflection/TypeBuilderExtensions.cs
+++ b/csharp/Platform.Reflection/TypeBuilderExtensions.cs
@@ -1,4 +1,3 @@
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 using System;
 using System.Reflection;

--- a/csharp/Platform.Reflection/TypeExtensions.cs
+++ b/csharp/Platform.Reflection/TypeExtensions.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Platform.Collections;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Platform.Reflection
 {

--- a/csharp/Platform.Reflection/Types.cs
+++ b/csharp/Platform.Reflection/Types.cs
@@ -4,7 +4,6 @@ using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1819 // Properties should not return arrays
 
 namespace Platform.Reflection

--- a/csharp/Platform.Reflection/Types[T1, T2, T3, T4, T5, T6, T7].cs
+++ b/csharp/Platform.Reflection/Types[T1, T2, T3, T4, T5, T6, T7].cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1819 // Properties should not return arrays
 
 namespace Platform.Reflection

--- a/csharp/Platform.Reflection/Types[T1, T2, T3, T4, T5, T6].cs
+++ b/csharp/Platform.Reflection/Types[T1, T2, T3, T4, T5, T6].cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1819 // Properties should not return arrays
 
 namespace Platform.Reflection

--- a/csharp/Platform.Reflection/Types[T1, T2, T3, T4, T5].cs
+++ b/csharp/Platform.Reflection/Types[T1, T2, T3, T4, T5].cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1819 // Properties should not return arrays
 
 namespace Platform.Reflection

--- a/csharp/Platform.Reflection/Types[T1, T2, T3, T4].cs
+++ b/csharp/Platform.Reflection/Types[T1, T2, T3, T4].cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1819 // Properties should not return arrays
 
 namespace Platform.Reflection

--- a/csharp/Platform.Reflection/Types[T1, T2, T3].cs
+++ b/csharp/Platform.Reflection/Types[T1, T2, T3].cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1819 // Properties should not return arrays
 
 namespace Platform.Reflection

--- a/csharp/Platform.Reflection/Types[T1, T2].cs
+++ b/csharp/Platform.Reflection/Types[T1, T2].cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1819 // Properties should not return arrays
 
 namespace Platform.Reflection

--- a/csharp/Platform.Reflection/Types[T].cs
+++ b/csharp/Platform.Reflection/Types[T].cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.ObjectModel;
 using Platform.Collections.Lists;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable CA1819 // Properties should not return arrays
 
 namespace Platform.Reflection


### PR DESCRIPTION
## Summary

This PR resolves issue #53 by ensuring all public classes and methods in the Platform.Reflection library have complete XML documentation comments.

### Changes Made:

- **AssemblyExtensions.cs**: Added missing XML documentation to the `GetLoadableTypes` method
- **DynamicExtensions.cs**: Fixed XML documentation parameter name for the `HasProperty` method  
- **NumericType.cs**: Fixed XML documentation cref reference for the static constructor
- **All files**: Removed `#pragma warning disable CS1591` directives since all public members now have proper documentation

### Verification

- ✅ All 20 C# files in Platform.Reflection now have complete XML documentation
- ✅ Build succeeds with 0 warnings and 0 errors
- ✅ All XML documentation follows the established project conventions
- ✅ No breaking changes to public API

## Test plan

- [x] Verify build succeeds without warnings
- [x] Confirm all public classes have XML documentation
- [x] Confirm all public methods have XML documentation  
- [x] Confirm all public properties have XML documentation
- [x] Validate XML documentation syntax is correct

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #53