### PR TITLE
Add tests for nullable numeric types CanBeNumeric property

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Reflection/issues/22
+Your prepared branch: issue-22-8ba7245c
+Your prepared working directory: /tmp/gh-issue-solver-1757834428521
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Reflection/issues/22
-Your prepared branch: issue-22-8ba7245c
-Your prepared working directory: /tmp/gh-issue-solver-1757834428521
-
-Proceed.

--- a/csharp/Platform.Reflection.Tests/NumericTypeTests.cs
+++ b/csharp/Platform.Reflection.Tests/NumericTypeTests.cs
@@ -9,5 +9,23 @@ namespace Platform.Reflection.Tests
         {
             Assert.True(NumericType<ulong>.IsNumeric);
         }
+
+        [Fact]
+        public void NullableIntCanBeNumericTest()
+        {
+            Assert.True(NumericType<int?>.CanBeNumeric);
+        }
+
+        [Fact]
+        public void NullableDoubleCanBeNumericTest()
+        {
+            Assert.True(NumericType<double?>.CanBeNumeric);
+        }
+
+        [Fact]
+        public void NullableBoolCanBeNumericTest()
+        {
+            Assert.True(NumericType<bool?>.CanBeNumeric);
+        }
     }
 }

--- a/csharp/experiments/NullableTest.cs
+++ b/csharp/experiments/NullableTest.cs
@@ -1,0 +1,22 @@
+using System;
+using Platform.Reflection;
+
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine($"int? CanBeNumeric: {NumericType<int?>.CanBeNumeric}");
+        Console.WriteLine($"int? IsNumeric: {NumericType<int?>.IsNumeric}");
+        Console.WriteLine($"int? IsNullable: {NumericType<int?>.IsNullable}");
+        Console.WriteLine($"int? UnderlyingType: {NumericType<int?>.UnderlyingType}");
+        
+        Console.WriteLine($"double? CanBeNumeric: {NumericType<double?>.CanBeNumeric}");
+        Console.WriteLine($"double? IsNumeric: {NumericType<double?>.IsNumeric}");
+        
+        Console.WriteLine($"bool? CanBeNumeric: {NumericType<bool?>.CanBeNumeric}");
+        Console.WriteLine($"bool? IsNumeric: {NumericType<bool?>.IsNumeric}");
+        
+        Console.WriteLine($"string? CanBeNumeric: {NumericType<string?>.CanBeNumeric}");
+        Console.WriteLine($"string? IsNumeric: {NumericType<string?>.IsNumeric}");
+    }
+}

--- a/csharp/experiments/NullableTypeTest/NullableTypeTest.csproj
+++ b/csharp/experiments/NullableTypeTest/NullableTypeTest.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Platform.Reflection\Platform.Reflection.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/csharp/experiments/NullableTypeTest/Program.cs
+++ b/csharp/experiments/NullableTypeTest/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Platform.Reflection;
+
+Console.WriteLine($"int? CanBeNumeric: {NumericType<int?>.CanBeNumeric}");
+Console.WriteLine($"int? IsNumeric: {NumericType<int?>.IsNumeric}");
+Console.WriteLine($"int? IsNullable: {NumericType<int?>.IsNullable}");
+Console.WriteLine($"int? UnderlyingType: {NumericType<int?>.UnderlyingType}");
+
+Console.WriteLine($"double? CanBeNumeric: {NumericType<double?>.CanBeNumeric}");
+Console.WriteLine($"double? IsNumeric: {NumericType<double?>.IsNumeric}");
+
+Console.WriteLine($"bool? CanBeNumeric: {NumericType<bool?>.CanBeNumeric}");
+Console.WriteLine($"bool? IsNumeric: {NumericType<bool?>.IsNumeric}");
+
+Console.WriteLine($"string? CanBeNumeric: {NumericType<string?>.CanBeNumeric}");
+Console.WriteLine($"string? IsNumeric: {NumericType<string?>.IsNumeric}");


### PR DESCRIPTION
## Summary
- Added comprehensive test cases for nullable numeric types (`int?`, `double?`, `bool?`) to verify they are correctly marked as `CanBeNumeric`
- Verified that the existing implementation already handles nullable numeric types correctly
- The `NumericType<T>` class properly extracts the underlying type for nullable types and checks if that type can be numeric

## Test plan
- [x] Added unit tests for nullable numeric types in `NumericTypeTests.cs`
- [x] Verified all existing tests still pass (12 total tests)
- [x] Created experimental code to demonstrate the functionality works as expected
- [x] Confirmed nullable numeric types (`int?`, `double?`, etc.) return `CanBeNumeric: True`
- [x] Confirmed non-numeric nullable types (`string?`) return `CanBeNumeric: False`

## Analysis
The issue was already resolved in the current implementation. The `NumericType<T>` constructor correctly:
1. Detects if a type is nullable using `type.IsNullable()`
2. Extracts the underlying type using `Nullable.GetUnderlyingType(type)`
3. Checks if the underlying type can be numeric using `underlyingType.CanBeNumeric()`

This means `int?` becomes `int`, `double?` becomes `double`, and so on, and since these underlying types are numeric, the nullable versions are correctly marked as `CanBeNumeric`.

Fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)